### PR TITLE
assignment of variables and methods to window

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,6 +3,6 @@
   "useTabs": false,
   "singleQuote": true,
   "jsxSingleQuote": true,
-  "semi":false,
+  "semi": false,
   "trailingComma": "none"
 }

--- a/src/_hooks_/useScript.js
+++ b/src/_hooks_/useScript.js
@@ -12,6 +12,7 @@ export default (url) => {
 
     return () => {
       document.body.removeChild(script)
+      window.myWidget = null
     }
   }, [url])
 }

--- a/src/functions/myWidget.js
+++ b/src/functions/myWidget.js
@@ -71,14 +71,15 @@ const myWidget = (
     if (!error && result && result.event === 'success') {
       logging && console.log('Done! Here is the image info: ', result.info)
       logging && console.log(result)
-      !!onSuccess && window.onSuccess(result)
+      !!window.cloudinaryOnSuccessCallback &&
+        window.cloudinaryOnSuccessCallback(result)
       if (destroy) {
         window.myWidget.destroy()
         window.myWidget = null
       }
     } else if (error) {
-      onFailure
-        ? onFailure({ error: error, result: result })
+      window.cloudinaryOnFailureCallback
+        ? window.cloudinaryOnFailureCallback({ error: error, result: result })
         : logging && console.log({ error: error, result: result })
       if (destroy) {
         window.myWidget.destroy()
@@ -91,12 +92,12 @@ const myWidget = (
     }
   }
 
+  window.cloudinaryOnSuccessCallback = onSuccess
+  window.cloudinaryOnFailureCallback = onFailure
+
   if (window.myWidget) {
-    debugger
-    window.onSuccess = onSuccess
     window.myWidget.update(widgetOptions)
   } else {
-    window.onSuccess = onSuccess
     window.myWidget = window.cloudinary.createUploadWidget(
       widgetOptions,
       resultCallback

--- a/src/functions/myWidget.js
+++ b/src/functions/myWidget.js
@@ -92,6 +92,7 @@ const myWidget = (
   }
 
   if (window.myWidget) {
+    debugger
     window.myWidget.update(widgetOptions)
   } else {
     window.myWidget = window.cloudinary.createUploadWidget(

--- a/src/functions/myWidget.js
+++ b/src/functions/myWidget.js
@@ -86,7 +86,7 @@ const myWidget = (
   }
 
   if (window.myWidget) {
-    window.myWidget.update(widgetOptions, resultCallback)
+    window.myWidget.update(widgetOptions)
   } else {
     window.myWidget = window.cloudinary.createUploadWidget(
       widgetOptions,

--- a/src/functions/myWidget.js
+++ b/src/functions/myWidget.js
@@ -27,70 +27,73 @@ const myWidget = (
   destroy,
   autoClose
 ) => {
-  debugger
-  window.myWidget ||=
-    !!window.cloudinary &&
-    window.cloudinary.createUploadWidget(
-      {
-        showCompletedButton: true,
-        multiple: multiple,
-        singleUploadAutoClose: autoClose,
-        showAdvancedOptions: true,
-        showPoweredBy: false,
-        styles: widgetStyles,
-        googleDriveClientId: googleDriveClientId,
-        sources: sources,
-        ...(sourceKeys && sourceKeys),
-        cloudName: cloudName,
-        uploadPreset: uploadPreset,
-        folder: folder,
-        cropping: cropping,
-        resourceType: resourceType,
-        ...(generateSignatureUrl && { use_filename: use_filename }),
-        ...(generateSignatureUrl && { eager: eager }),
-        ...(generateSignatureUrl && { unique_filename: unique_filename }),
-        ...(generateSignatureUrl && {
-          prepareUploadParams: async (cb, params) =>
-            await generateSignature(
-              cb,
-              params,
-              {
-                generateSignatureUrl,
-                accepts,
-                contentType,
-                withCredentials,
-                customPublicId,
-                eager,
-                apiKey,
-                resourceType,
-                unique_filename,
-                use_filename
-              },
-              logging
-            )
-        })
-      },
-      (error, result) => {
-        if (!error && result && result.event === 'success') {
-          logging && console.log('Done! Here is the image info: ', result.info)
-          logging && console.log(result)
-          !!onSuccess && onSuccess(result)
-          destroy && window.widget.destroy()
-        } else if (error) {
-          onFailure
-            ? onFailure({ error: error, result: result })
-            : logging && console.log({ error: error, result: result })
-          destroy && window.widget.destroy()
-        } else if (!!resourceType && result.info === 'shown') {
-          logging && console.log('setting resourceType')
-          // document.querySelector(
-          //   '.cloudinary_fileupload'
-          // ).accept = `${resourceType}/*`
-        } else {
-          logging && console.log(result)
-        }
-      }
+  const widgetOptions = {
+    showCompletedButton: true,
+    multiple: multiple,
+    singleUploadAutoClose: autoClose,
+    showAdvancedOptions: true,
+    showPoweredBy: false,
+    styles: widgetStyles,
+    googleDriveClientId: googleDriveClientId,
+    sources: sources,
+    ...(sourceKeys && sourceKeys),
+    cloudName: cloudName,
+    uploadPreset: uploadPreset,
+    folder: folder,
+    cropping: cropping,
+    resourceType: resourceType,
+    ...(generateSignatureUrl && { use_filename: use_filename }),
+    ...(generateSignatureUrl && { eager: eager }),
+    ...(generateSignatureUrl && { unique_filename: unique_filename }),
+    ...(generateSignatureUrl && {
+      prepareUploadParams: async (cb, params) =>
+        generateSignature(
+          cb,
+          params,
+          {
+            generateSignatureUrl,
+            accepts,
+            contentType,
+            withCredentials,
+            customPublicId,
+            eager,
+            apiKey,
+            resourceType,
+            unique_filename,
+            use_filename
+          },
+          logging
+        )
+    })
+  }
+
+  const resultCallback = (error, result) => {
+    if (!error && result && result.event === 'success') {
+      logging && console.log('Done! Here is the image info: ', result.info)
+      logging && console.log(result)
+      !!onSuccess && onSuccess(result)
+      destroy && window.widget.destroy()
+    } else if (error) {
+      onFailure
+        ? onFailure({ error: error, result: result })
+        : logging && console.log({ error: error, result: result })
+      destroy && window.widget.destroy()
+    } else if (!!resourceType && result.info === 'shown') {
+      logging && console.log('setting resourceType')
+    } else {
+      logging && console.log(result)
+    }
+  }
+
+  if (window.myWidget) {
+    window.myWidget.update(widgetOptions, resultCallback)
+  } else {
+    window.myWidget = window.cloudinary.createUploadWidget(
+      widgetOptions,
+      resultCallback
     )
+  }
+
   window.myWidget.open()
 }
 

--- a/src/functions/myWidget.js
+++ b/src/functions/myWidget.js
@@ -72,12 +72,18 @@ const myWidget = (
       logging && console.log('Done! Here is the image info: ', result.info)
       logging && console.log(result)
       !!onSuccess && onSuccess(result)
-      destroy && window.myWidget.destroy()
+      if (destroy) {
+        window.myWidget.destroy()
+        window.myWidget = null
+      }
     } else if (error) {
       onFailure
         ? onFailure({ error: error, result: result })
         : logging && console.log({ error: error, result: result })
-      destroy && window.myWidget.destroy()
+      if (destroy) {
+        window.myWidget.destroy()
+        window.myWidget = null
+      }
     } else if (!!resourceType && result.info === 'shown') {
       logging && console.log('setting resourceType')
     } else {

--- a/src/functions/myWidget.js
+++ b/src/functions/myWidget.js
@@ -71,7 +71,7 @@ const myWidget = (
     if (!error && result && result.event === 'success') {
       logging && console.log('Done! Here is the image info: ', result.info)
       logging && console.log(result)
-      !!onSuccess && onSuccess(result)
+      !!onSuccess && window.onSuccess(result)
       if (destroy) {
         window.myWidget.destroy()
         window.myWidget = null
@@ -93,8 +93,10 @@ const myWidget = (
 
   if (window.myWidget) {
     debugger
+    window.onSuccess = onSuccess
     window.myWidget.update(widgetOptions)
   } else {
+    window.onSuccess = onSuccess
     window.myWidget = window.cloudinary.createUploadWidget(
       widgetOptions,
       resultCallback

--- a/src/functions/myWidget.js
+++ b/src/functions/myWidget.js
@@ -72,12 +72,12 @@ const myWidget = (
       logging && console.log('Done! Here is the image info: ', result.info)
       logging && console.log(result)
       !!onSuccess && onSuccess(result)
-      destroy && window.widget.destroy()
+      destroy && window.myWidget.destroy()
     } else if (error) {
       onFailure
         ? onFailure({ error: error, result: result })
         : logging && console.log({ error: error, result: result })
-      destroy && window.widget.destroy()
+      destroy && window.myWidget.destroy()
     } else if (!!resourceType && result.info === 'shown') {
       logging && console.log('setting resourceType')
     } else {


### PR DESCRIPTION
Due to the nature of the cloudinary widget mechanism. When clicking on the assigned button, an entire new widget is launched each time. Whilst the performance impact is negligible, it meant that sources like google drive would need to be authenticated for every new widget you opened. To mitigate this the following has been added, 

- after calling for a new widget 'createUploadWidget', it is assigned to window and therefore is able to accessed globally within the dom. 
- due to restrictions enforced by cloudinary, the widget has an 'update' method but you are not able to update the callbacks, so any new uploads would revert back to the component where the widget was originally created. onSuccess and onFailure are also now assigned to window under 'cloudinaryOn(success or failure)callback' and new opens of the widget will return responses to the expected location. 